### PR TITLE
Install jx-app-datadog on raccoon 

### DIFF
--- a/env/jx-app-datadog/values.tmpl.yaml
+++ b/env/jx-app-datadog/values.tmpl.yaml
@@ -1,0 +1,22 @@
+datadog:
+  datadog:
+    apiKey: vault:datadog-app:apiKey
+    clusterName: raccoonshimmer
+    tags:
+      - env:dev
+    nonLocalTraffic: true
+    collectEvents: true
+    leaderElection: true
+    logsEnabled: true
+    logsConfigContainerCollectAll: false
+    apmEnabled: true
+    processAgentEnabled: false
+    resources:
+      requests:
+        cpu: 200m
+        memory: 256Mi
+      limits:
+        cpu: 300m
+        memory: 512Mi
+  daemonset:
+    useHostPort: true

--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -34,3 +34,6 @@ dependencies:
 - alias: tekton
   name: tekton
   repository: https://storage.googleapis.com/chartmuseum.jenkins-x.io
+- name: jx-app-datadog
+  repository: https://storage.googleapis.com/chartmuseum.jenkins-x.io
+  version: 0.0.7


### PR DESCRIPTION
Install DataDog app with APM enabled (will not be charged/enabled if no application is instrumented).

The secret `vault:datadog-app:apiKey` has already been created.

See https://github.com/cloudbees/arcalos/issues/481