### PR TITLE
improvement: add tag clustername for all metrics

### DIFF
--- a/env/jx-app-datadog/values.tmpl.yaml
+++ b/env/jx-app-datadog/values.tmpl.yaml
@@ -4,6 +4,7 @@ datadog:
     clusterName: raccoonshimmer
     tags:
       - env:dev
+      - clustername:raccoonshimmer
     nonLocalTraffic: true
     collectEvents: true
     leaderElection: true


### PR DESCRIPTION
Some metrics doesn't provide tag clustername. Adding it at this level permits to filter metrics more easily on DataDog UI.