### PR TITLE
chore(deps): bump arcalos-jenkins-x-versions from 0.0.223 to 0.0.260

### DIFF
--- a/jx-requirements.yml
+++ b/jx-requirements.yml
@@ -84,6 +84,6 @@ vault:
   serviceAccount: raccoonshimmer-vt
 velero: {}
 versionStream:
-  ref: v0.0.223
+  ref: v0.0.260
   url: https://github.com/cloudbees/arcalos-jenkins-x-versions.git
 webhook: prow


### PR DESCRIPTION
Signed-off-by: Mark Cox <markcox20@hotmail.com>